### PR TITLE
Fix incorrect localhost address specified for the /monitor path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The six interfaces of the RAMES:
 
 you can test the GET interface by using the browser. For example, you can test the /monitor interface by entering the following URL in the browser:
 
-www.localhost:5000/monitor
+www.localhost:50000/monitor
 
 For the POST, you need to run it by using the curl command. 
 It's a bit complex to test the POST interface, please read the dataclass and execute() in the api.py carefully to understand the data structure of the POST request.


### PR DESCRIPTION
The address specified is: www.localhost:5000/monitor. This gives a localhost refused to connect error because this is the incorrect path.

The correct path is this one: www.localhost:50000/monitor